### PR TITLE
Improve wiki pages (DM)

### DIFF
--- a/clips-plugins/deluxemenus/options-and-configurations/README.md
+++ b/clips-plugins/deluxemenus/options-and-configurations/README.md
@@ -2,6 +2,24 @@
 description: About the plugin's options and configurations
 ---
 
+<!-- Spigot (related) links -->
+[1.8.8]: https://helpch.at/docs/1.8.8/org/bukkit/Material.html
+[1.12.2]: https://helpch.at/docs/1.12.2/org/bukkit/Material.html
+[1.13.2]: https://helpch.at/docs/1.13.2/org/bukkit/Material.html
+[1.14.4]: https://helpch.at/docs/1.14.4/org/bukkit/Material.html
+[Latest]: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html
+[Enchantments]: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/enchantments/Enchantment.html
+[Colors]: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/DyeColor.html
+[Patterns]: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/banner/PatternType.html
+[Sounds]: https://gist.github.com/Andre601/1ab3b4fabd0010ae241156333491c379
+
+<!-- Plugin links -->
+[Vault]: https://www.spigotmc.org/resources/34315/
+
+<!-- Other links -->
+[Placeholders]: https://helpch.at/placeholders
+[minecraftjson]: https://minecraftjson.com/
+
 # Options & Configurations
 
 **DeluxeMenus** is a highly customizable plugin, it has many options and configurations to give you the ability to change everything you want to make your custom menus that fits your server's layout.  
@@ -9,54 +27,54 @@ It has **GUI** options to manage the GUI menu, and **Item** options to manage ev
 
 ## Useful links
 
-* [Placeholders](https://helpch.at/placeholders)
+* [Placeholders]
 * Materials
-  * [1.8.8](https://helpch.at/docs/1.8.8/org/bukkit/Material.html)
-  * [1.12.2](https://helpch.at/docs/1.12.2/org/bukkit/Material.html)
-  * [1.13.2](https://helpch.at/docs/1.13.2/org/bukkit/Material.html)
-  * [1.14.4](https://helpch.at/docs/1.14.4/org/bukkit/Material.html)
-  * [Latest](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/Material.html)
-* [Enchantments](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/enchantments/Enchantment.html) \(Be aware that some enchantments are not available on some items.\)
-* [Dye Colors](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/DyeColor.html)
-* [Pattern Types](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/banner/PatternType.html)
-* [Sound Types](https://gist.github.com/Andre601/1ab3b4fabd0010ae241156333491c379)
+  * [1.8.8]
+  * [1.12.2]
+  * [1.13.2]
+  * [1.14.4]
+  * [Latest]
+* [Enchantments] (Be aware that some enchantments are not available on some items.)
+* [Dye Colors][Colors]
+* [Banner Patterns][Patterns]
+* [Sound Types][Sounds]
 
 ## Values keywords
 
-| Keyword | Description |
-| :--- | :--- |
-| **BOOLEAN** | Replace this with `true` or `false` \(If used with a PlaceholderAPI placeholder, this will be `yes` or `no` instead of `true`/`false` \[It's changeable from PlaceholderAPI config file, but `yes`/`no` are the default values\]\). |
-| **TEXT** | Replace this with any text. Check the description to find out if you can use color/formatting codes. |
-| **\#** | Replace this with a number. Check the description to see if there are limits. |
-| **COMMAND** | Replace this with a command without slash \(`/`\). |
-| **SOUND** | Replace this with a sound name. |
-| **EXPRESSION** | Replace this with a java/placeholder expression/comparison. See [this](requirements.md) page for more information. |
+| Keyword        | Description                                                                                                                                                                               |
+| :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **BOOLEAN**    | Replace this with `true` or `false` (If used with a PlaceholderAPI placeholder, this will be `yes` or `no` instead of `true`/`false` [It's changeable from PlaceholderAPI config file.]). |
+| **TEXT**       | Replace this with any text. Check the description to find out if you can use color/formatting codes.                                                                                      |
+| **\#**         | Replace this with a number. Check the description to see if there are limits.                                                                                                             |
+| **COMMAND**    | Replace this with a command without slash (`/`).                                                                                                                                          |
+| **SOUND**      | Replace this with a sound name.                                                                                                                                                           |
+| **EXPRESSION** | Replace this with a java/placeholder expression/comparison. See [this](requirements.md) page for more information.                                                                        |
 
 ## Actions types
 
-| Tag | Description |
-| :--- | :--- |
-| `[player] <command>` | Executes a command as the player. |
-| `[console] <command>` | Executes a command from the console. |
-| `[commandevent] <command>` | Executes an unregistered command ad the player. |
-| `[message] <text>` | Sends a message to the player. You can use [placeholders](https://helpch.at/placeholders) and color/format codes here. |
-| `[openguimenu] <menu-name>` | Opens another GUI from DeluxeMenus. |
-| `[connect] <server-name>` | Connects the player to a server on the same BungeeCord. |
-| `[close]` | Closes the currently opened GUI. |
-| `[json] <JSON-text>` | Send a json message to the player. Use [this](https://minecraftjson.com/) website to easily generate the JSON text. |
-| `[refresh]` | Refresh items in the current menu view. This updates the shown Items themselves. |
-| `[broadcastsound] <sound>` | Broadcast a sound to all players on the server. |
-| `[sound] <sound>` | Play a sound for the player. |
-| `[takemoney] <amount>` | Take a certain amount of money from the player. [Vault](https://www.spigotmc.org/resources/34315/) is required for this action to work. |
+| Tag                         | Description                                                                                            |
+| :-------------------------- | :----------------------------------------------------------------------------------------------------- |
+| `[player] <command>`        | Executes a command as the player.                                                                      |
+| `[console] <command>`       | Executes a command from the console.                                                                   |
+| `[commandevent] <command>`  | Executes an unregistered command ad the player.                                                        |
+| `[message] <text>`          | Sends a message to the player. You can use [placeholders] and color/format codes here.                 |
+| `[openguimenu] <menu-name>` | Opens another GUI from DeluxeMenus.                                                                    |
+| `[connect] <server-name>`   | Connects the player to a server on the same BungeeCord.                                                |
+| `[close]`                   | Closes the currently opened GUI.                                                                       |
+| `[json] <JSON-text>`        | Send a json message to the player. Use [this][minecraftjson] website to easily generate the JSON text. |
+| `[refresh]`                 | Refresh items in the current menu view. This updates the shown Items themselves.                       |
+| `[broadcastsound] <sound>`  | Broadcast a sound to all players on the server.                                                        |
+| `[sound] <sound>`           | Play a sound for the player.                                                                           |
+| `[takemoney] <amount>`      | Take a certain amount of money from the player. [Vault] is required for this action to work.           |
 
 ### **Action tags**
 
-These tags can be added with the action \(e.g. `- '[message] example<delay=20>'`\).
+These tags can be added with the action (e.g. `- '[message] example<delay=20>'`).
 
-| Tag | Description |
-| :--- | :--- |
-| `<delay=<time>>` | Executes the action after the specified delay \(in ticks, 20 ticks = 1 second\). |
-| `<chance=<chance>>` | Sets a chance to execute the action. |
+| Tag                 | Description                                                                    |
+| :------------------ | :----------------------------------------------------------------------------- |
+| `<delay=<time>>`    | Executes the action after the specified delay (in ticks, 20 ticks = 1 second). |
+| `<chance=<chance>>` | Sets a chance to execute the action.                                           |
 
 ## General options
 

--- a/clips-plugins/deluxemenus/options-and-configurations/item.md
+++ b/clips-plugins/deluxemenus/options-and-configurations/item.md
@@ -2,6 +2,16 @@
 description: All item related options & configurations
 ---
 
+[Base64]: https://minecraft-heads.com
+[EpicHeads]: https://songoda.com/marketplace/product/26
+[HeadDatabase]: https://www.spigotmc.org/resources/14280/
+[Placeholder]: https://helpch.at/placeholders
+[Data]: https://minecraft-el.gamepedia.com/Data_values
+
+[Colors]: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/DyeColor.html
+[Patterns]: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/banner/PatternType.html
+[Enchantments]: https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/enchantments/Enchantment.html
+
 # Item
 
 ## Syntax
@@ -14,7 +24,7 @@ description: All item related options & configurations
 > ```
 
 **Note:**  
-Each item will have a name, in this example our item is called **\*\*`ItemName`. This name** should\*\* be unique, so there won't be two or more items with the same name.
+Each item will have a name, in this example our item is called **`ItemName`**. This name **should** be unique, so there won't be two or more items with the same name.
 
 ## Material
 
@@ -24,20 +34,20 @@ Each item will have a name, in this example our item is called **\*\*`ItemName`.
 >
 > > **Supported material values:**
 > >
-> > * [Material name](./#useful-links) \(`STONE`\).
-> > * Player head \(`head;extended_clip`\).
-> > * Placeholder head \(`head;%player_name%`\).
-> > * Argument placeholder head \(`head;{target}`\).
-> > * [BaseHead](https://minecraft-heads.com) \(`basehead-<base64 (Value field in the head's give command)>`\).
-> > * [EpicHeads](https://songoda.com/marketplace/product/26) \(`heads-<ID>`\).
-> > * [HeadDatabase](https://www.spigotmc.org/resources/14280/) \(`hdb-<ID>`\).
-> > * [Placeholder](https://helpch.at/placeholders) material \(`placeholder-%player_item_in_hand%`\).
+> > * [Material name](./#useful-links) (`STONE`).
+> > * Player head (`head;extended_clip`).
+> > * Placeholder head (`head;%player_name%`).
+> > * Argument placeholder head (`head;{target}`).
+> > * [Base64] head (`basehead-<base64 (Value field in the head's give command)>`).
+> > * [EpicHeads] head (`heads-<ID>`).
+> > * [HeadDatabase] head (`hdb-<ID>`).
+> > * [Placeholder] material \(`placeholder-%player_item_in_hand%`\ [Placeholder needs to return a material name]).
 
 Sets the material of the item in the menu.
 
 {% hint style="info" %}
 For version 1.12.2 or older:  
-Check [Data](item.md#data) option to specify the data of the item \(the number after the colon `:`\). e.g. Lime Wool would be
+Check [Data](#data) option to specify the data of the item (the number after the colon `:`). e.g. Lime Wool would be
 
 ```yaml
 material: WOOL
@@ -53,14 +63,14 @@ data: 5
 >
 > > **Supported data values:**
 > >
-> > * Number \(`1`\).
-> > * Placeholder that returns a number \(`placeholder-%player_item_in_hand_data%`\).
+> > * Number (`1`).
+> > * [Placeholder] that returns a number (`placeholder-%player_item_in_hand_data%`).
 
-Sets the durability of the item \(depends on the [Material](item.md#material) option\).
+Sets the durability of the item (depends on the [Material](#material) option).
 
 {% hint style="info" %}
 For version 1.12.2 or older:  
-This option will specify the [data value](https://minecraft-el.gamepedia.com/Data_values) \(the number after the colon `:`\) of the item or the item's durability \(depends on the [Material](item.md#material) option\).
+This option will specify the [data value][Data] (the number after the colon `:`) of the item or the item's durability (depends on the [Material](#material) option).
 {% endhint %}
 
 ## Amount
@@ -77,7 +87,7 @@ Sets the item's amount in the menu.
 > dynamic_amount: '%placeholder%'
 > ```
 
-Sets the item's amount in the menu using a [placeholder](https://helpch.at/placeholders).
+Sets the item's amount in the menu using a [placeholders][Placeholder].
 
 ## Banner Meta
 
@@ -87,10 +97,10 @@ Sets the item's amount in the menu using a [placeholder](https://helpch.at/place
 > - <dyecolor>;<patterntype>
 > ```
 >
-> > * [Dye colors list](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/DyeColor.html).
-> > * [Pattern types list](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/block/banner/PatternType.html).
+> > * [Dye colors][Colors]
+> > * [Banner Patterns][Patterns]
 
-Allows you to create your custom banner \(Used if the [material](item.md#material) is a banner\).
+Allows you to create your custom banner (Used if the [material](#material) is a banner).
 
 ## RGB <a id="rgb"></a>
 
@@ -106,7 +116,7 @@ Allows you to create your custom banner \(Used if the [material](item.md#materia
 > >
 > > ![Image of what will be displayed](https://img.aboodyy.net/19.06.19_01-07.png)
 
-Sets the RGB \(Red, Green, Blue\) color for leather armor.
+Sets the RGB (Red, Green, Blue) color for leather armor.
 
 ## Display Name
 
@@ -114,7 +124,7 @@ Sets the RGB \(Red, Green, Blue\) color for leather armor.
 > display_name: "TEXT"
 > ```
 
-Sets the item's display name. You can use [placeholders](https://helpch.at/placeholders) and color/format codes.
+Sets the item's display name. You can use [placeholders][Placeholder] and color/format codes.
 
 ## Lore
 
@@ -124,7 +134,7 @@ Sets the item's display name. You can use [placeholders](https://helpch.at/place
 >   - "TEXT"
 > ```
 
-Sets the item's lore \(the text shown under the item's name\). You can use [placeholders](https://helpch.at/placeholders) and color/format codes in this area.
+Sets the item's lore (the text shown under the item's name\). You can use [placeholders][Placeholder] and color/format codes in this area.
 
 ## Slot
 
@@ -141,11 +151,11 @@ Sets the item's lore \(the text shown under the item's name\). You can use [plac
 > >   - #
 > > ```
 
-Sets in which slot the item should be inside the menu.
+Sets in which slot(s) the item should be inside the menu.
 
 {% hint style="info" %}
 * Slots start at 0.
-* Multiple items can be in the same slot, but you'll have to use [view requirement](item.md#view-requirement) and [priority](item.md#priority) options to work properly.
+* Multiple items can be in the same slot, but you'll have to use [view requirement](#view-requirement) and [priority](#priority) options to work properly.
 {% endhint %}
 
 ![Slots number in a chest](https://i.imgur.com//lr41ykP.png)
@@ -170,7 +180,7 @@ The item that has the highest priority will be checked first if the player has t
 > view_requirement: 'EXPRESSION'
 > ```
 
-Sets the requirements the player should have to see the item. \(Check [priority](item.md#priority) option for setting up multiple items in the same slot\).  
+Sets the requirements the player should have to see the item. (Check [priority](#priority) option for setting up multiple items in the same slot).  
 Check the [Requirements](requirements.md) page for more info about this option's value and how to use it.
 
 ## Update
@@ -179,8 +189,9 @@ Check the [Requirements](requirements.md) page for more info about this option's
 > update: BOOLEAN # true or false
 > ```
 
-If set to true, it will update the placeholders in the item's [display name](item.md#display-name) and [lore](item.md#lore) **only**.  
-Check the [update interval](gui.md#update-interval) GUI option to set the update speed.
+If set to true, it will update the placeholders in the item's [display name](#display-name) and [lore](#lore) **only**.  
+Check the [update interval](#update-interval) GUI option to set the update speed.  
+**This won't update the displayed item itself! Use the [\[refresh\] command](#shift-leftmiddleright-click-commands) to update the item.**
 
 ![An example showing how the update option works in placeholders](https://i.imgur.com/iOKtT2A.gif)
 
@@ -192,9 +203,9 @@ Check the [update interval](gui.md#update-interval) GUI option to set the update
 >   - enchantmentid;level
 > ```
 >
-> > * [Enchantments list](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/enchantments/Enchantment.html).
+> > * [Enchantments list][Enchantments]
 
-Enchants the item with the specified enchantments. \(Check the [hide enchantments](item.md#hide-enchantments) option to hide the enchantments\)
+Enchants the item with the specified enchantments. (Check the [hide enchantments](#hide-enchantments) option to hide the enchantments)
 
 {% hint style="warning" %}
 Some items cannot have the enchanting glow effect
@@ -206,7 +217,7 @@ Some items cannot have the enchanting glow effect
 > hide_enchantments: BOOLEAN # true or false
 > ```
 
-If set to true, it will hide the enchantments you set for the item using the [enchantments](item.md#enchantments) option from the item's tooltip \(lore\).  
+If set to true, it will hide the enchantments you set for the item using the [enchantments](#enchantments) option from the item's tooltip (lore).  
 Used to add the enchanting glow effect to the item without showing the enchantments text.
 
 ## Hide Attributes
@@ -215,7 +226,7 @@ Used to add the enchanting glow effect to the item without showing the enchantme
 > hide_attributes: BOOLEAN # true or false
 > ```
 
-If set to true, it will hide the vanilla attributes of an item/armor \(e.g. **7 Attack Damage**\).
+If set to true, it will hide the vanilla attributes of an item/armor (e.g. **# Attack Damage**).
 
 ## Hide Effects
 
@@ -225,7 +236,7 @@ If set to true, it will hide the vanilla attributes of an item/armor \(e.g. **7 
 
 If set to true, it will hide the potion's effect text beneath the item name.
 
-## \(Shift\) Left/Middle/Right click Commands
+## (Shift) Left/Middle/Right click Commands
 
 > ```yaml
 > # left_click_commands: or
@@ -240,7 +251,7 @@ If set to true, it will hide the potion's effect text beneath the item name.
 Sets the actions/commands that should be executed once the player clicks the item. they get executed in order from top to bottom.  
 Check [this](./#action-tags) for all action types and action tags.
 
-## \(Shift\) Left/Middle/Right click Requirement
+## (Shift) Left/Middle/Right click Requirement
 
 > ```yaml
 > # left_click_requirement: or
@@ -254,8 +265,8 @@ Check [this](./#action-tags) for all action types and action tags.
 >     - "[ACTIONTYPE] ACTION"
 > ```
 
-Sets the requirements the player should have to click the item \(Check the [Requirements](requirements.md) page for more info about the `EXPRESSION` value\).  
-Deny commands \(optional\) are the actions that are going to be executed if the player doesn't have the required requirements. But if \(s\)he does, it will execute the actions specified in the [click commands](item.md#shift-left-middle-right-click-commands) option.
+Sets the requirements the player should have to click the item (Check the [Requirements](requirements.md) page for more info about the `EXPRESSION` value).  
+Deny commands (optional) are the actions that are going to be executed if the player doesn't have the required requirements. But if \(s\)he does, it will execute the actions specified in the [click commands](#shift-left-middle-right-click-commands) option.
 
 Check [this](./#action-tags) for all action types and action tags.
 


### PR DESCRIPTION
Improved `README.md` and the `item.md` in the options-and-configurations section.

Improvements:
- Made table actually readable.
- Grouped up links at the top of the page for easy updating and changing
- Changed `[text](file.md#text)` to `[text](#text)`
- Removed useless/not needed backslashes from () and []

If for whatever reason the wiki-software you use doesn't support those changes, get a better alternative like [MkDocs](https://mkdocs.org)