### PR TITLE
Fix Priority comment, add missing dot in permission

### DIFF
--- a/helpchat-plugins/chatchat/formats.md
+++ b/helpchat-plugins/chatchat/formats.md
@@ -31,12 +31,11 @@ Priority formats have everything that Basic Formats have but they also have a pr
 If a player has access to multiple formats, the priority will decide what format will be used when they sends a message in chat.
 
 {% hint style="info" %}
-Lower Number = Higher Priority
-{% endhint %}
+The `addons.deluxechat.inverse_priorities` setting in `extensions.yml` dictates if the lowest or the highest number has priority. If this setting is true, lower numbers have higher priority. If this setting is false, it is the other way around.{% endhint %}
 
 ## Permissions
 
-Formats are given away to players using permissions. Every format has a similar permission and that is: `chatchat.format<format-name>`
+Formats are given away to players using permissions. Every format has a similar permission and that is: `chatchat.format.<format-name>`
 
 ## Default Format
 


### PR DESCRIPTION
[This](https://github.com/HelpChat/ChatChat/commit/11fb0ae2d0a638567cbec058acf91fae5626be3d) commit has introduced a behaviour breaking change from older versions because the default value is false. 
[This](https://github.com/HelpChat/ChatChat/blob/85a82b92a8ee9a618f548c446511a5b1b4ba64df/plugin/src/main/java/at/helpch/chatchat/util/FormatUtils.java#L35) line shows it's the correct behaviour.
This was not reflected in the wiki.
Also added a missed dot in the permission